### PR TITLE
Cross vendor fixes (GPU and GPU)

### DIFF
--- a/Build/Stardust.vcxproj
+++ b/Build/Stardust.vcxproj
@@ -101,7 +101,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>SDL_MAIN_HANDLED;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\Src;..\External\Mantle\Include;..\Src\Framework;..\External\SDL2\Include;..\External;..\External\XGL\Include;..\External\Vulkan\Include</AdditionalIncludeDirectories>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>

--- a/Src/Framework/VKU_Platform.c
+++ b/Src/Framework/VKU_Platform.c
@@ -343,7 +343,7 @@ void VKU_Quit(void)
 //-----------------------------------------------------------------------------
 int VKU_Present(uint32_t *image_indice)
 {
-    VkResult result[1];
+	VkResult result[1] = { 0 };
     VkPresentInfoKHR present_info = { 0 };
     present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     present_info.pNext = NULL;


### PR DESCRIPTION
I'm currently trying to get this demo running on non-Intel Hardware. This includes GPUs and CPUs from different vendors, so feel free to merge this PR if you want to have the example run across different vendors.

https://github.com/GameTechDev/stardust_vulkan/pull/2/commits/07885522c2ea15f1ab78e29a22e62fabedcbc4f8 :

Downgrade to AVX instead of AVX2, this makes the demo work on AMD processors that don't support AVX2.

https://github.com/GameTechDev/stardust_vulkan/pull/2/commits/5f6680f588b8dbe81314937b9d72f6040e50b18c :

Actually I don't think the pResult is necessary at all, as the example is only using one swap chain so the result from vkQueuePresentKHR should be sufficient. But to make this work and AMD GPUs it's enough to initialize the pResults array to zero.

With these changes the examples work on AMD CPU + GPU.

NVIDIA will proably require a few more changes (optimal tiling and staging for the cubemap, see #1), which is the next thing I'll be implementing :wink: 
