### PR TITLE
Image staging and memory type lookups for cross vendor support

### DIFF
--- a/Build/Stardust.vcxproj
+++ b/Build/Stardust.vcxproj
@@ -126,7 +126,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>SDL_MAIN_HANDLED;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\Src;..\External\Mantle\Include;..\Src\Framework;..\External\SDL2\Include;..\External;..\External\XGL\Include;..\External\Vulkan\Include</AdditionalIncludeDirectories>
-      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <Link>

--- a/Src/Framework/VKU.c
+++ b/Src/Framework/VKU.c
@@ -168,29 +168,12 @@ int VKU_Alloc_Buffer_Object(VKU_BUFFER_MEMORY_POOL *mempool,
 int VKU_Alloc_Image_Object(VKU_IMAGE_MEMORY_POOL *mempool,
     VkImage           image,
     VkDeviceSize     *offset,
-	VkMemoryPropertyFlags memprops)
+	uint32_t          memtypeindex)
 {
     if (!mempool || !image) LOG_AND_RETURN0();
 
 	VkMemoryRequirements mreq;
 	vkGetImageMemoryRequirements(mempool->device, image, &mreq);
-
-	// Get memory type index for requested memory flags
-	VkPhysicalDeviceMemoryProperties devicememprops;
-	vkGetPhysicalDeviceMemoryProperties(mempool->device, &memprops);
-	uint32_t memtypeindex = 0;
-	for (uint32_t i = 0; i < 32; i++)
-	{
-		if ((mreq.memoryTypeBits & 1) == 1)
-		{
-			if ((devicememprops.memoryTypes[i].propertyFlags & memprops) == memtypeindex)
-			{
-				memtypeindex = i;
-				break;
-			}
-		}
-		mreq.memoryTypeBits >>= 1;
-	}
 
     if (mreq.size > 0) {
         VkDeviceSize off;

--- a/Src/Framework/VKU.h
+++ b/Src/Framework/VKU.h
@@ -96,7 +96,8 @@ int VKU_Alloc_Buffer_Object(VKU_BUFFER_MEMORY_POOL *objpool,
 
 int VKU_Alloc_Image_Object(VKU_IMAGE_MEMORY_POOL *objpool,
                            VkImage               image,
-                           VkDeviceSize          *offset);
+                           VkDeviceSize          *offset,
+						   VkMemoryPropertyFlags memprps);
 
 
 int VKU_Load_Shader(VkDevice        device,

--- a/Src/Framework/VKU.h
+++ b/Src/Framework/VKU.h
@@ -97,7 +97,7 @@ int VKU_Alloc_Buffer_Object(VKU_BUFFER_MEMORY_POOL *objpool,
 int VKU_Alloc_Image_Object(VKU_IMAGE_MEMORY_POOL *objpool,
                            VkImage               image,
                            VkDeviceSize          *offset,
-						   VkMemoryPropertyFlags memprps);
+						   uint32_t              memtypeindex);
 
 
 int VKU_Load_Shader(VkDevice        device,

--- a/Src/Stardust_VK.c
+++ b/Src/Stardust_VK.c
@@ -631,7 +631,7 @@ static int Create_Depth_Stencil(void)
         VK_SHARING_MODE_EXCLUSIVE, 0, NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &ds_info, NO_ALLOC_CALLBACK, &s_depth_stencil_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_depth_stencil_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_depth_stencil_image, NULL, Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))) LOG_AND_RETURN0();
 
     VkComponentMapping channels = {
         VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A 
@@ -1681,7 +1681,7 @@ static int Create_Float_Image_And_Framebuffer(void)
         VK_SHARING_MODE_EXCLUSIVE, 0, NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_float_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_float_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_float_image, NULL, Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))) LOG_AND_RETURN0();
 
     VkImageViewCreateInfo image_view = {
         VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0, s_float_image, VK_IMAGE_VIEW_TYPE_2D,
@@ -1717,7 +1717,7 @@ static int Create_Skybox_Image(void)
         NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_skybox_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_skybox_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_skybox_image, NULL, Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))) LOG_AND_RETURN0();
 
     VkImageViewCreateInfo image_view_info = {
         VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
@@ -1741,7 +1741,7 @@ static int Create_Palette_Images(void)
             NULL, VK_IMAGE_LAYOUT_UNDEFINED
         };
         VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_palette_image[i]));
-        if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_palette_image[i], NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) return 0;
+        if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_palette_image[i], NULL, Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))) return 0;
 
         VkImageViewCreateInfo image_view_info = {
             VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,

--- a/Src/Stardust_VK.c
+++ b/Src/Stardust_VK.c
@@ -631,7 +631,7 @@ static int Create_Depth_Stencil(void)
         VK_SHARING_MODE_EXCLUSIVE, 0, NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &ds_info, NO_ALLOC_CALLBACK, &s_depth_stencil_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_depth_stencil_image, NULL)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_depth_stencil_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
 
     VkComponentMapping channels = {
         VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A 
@@ -1681,7 +1681,7 @@ static int Create_Float_Image_And_Framebuffer(void)
         VK_SHARING_MODE_EXCLUSIVE, 0, NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_float_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_float_image, NULL)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_target, s_float_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
 
     VkImageViewCreateInfo image_view = {
         VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0, s_float_image, VK_IMAGE_VIEW_TYPE_2D,
@@ -1717,7 +1717,7 @@ static int Create_Skybox_Image(void)
         NULL, VK_IMAGE_LAYOUT_UNDEFINED
     };
     VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_skybox_image));
-    if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_skybox_image, NULL)) LOG_AND_RETURN0();
+    if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_skybox_image, NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) LOG_AND_RETURN0();
 
     VkImageViewCreateInfo image_view_info = {
         VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
@@ -1741,7 +1741,7 @@ static int Create_Palette_Images(void)
             NULL, VK_IMAGE_LAYOUT_UNDEFINED
         };
         VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &s_palette_image[i]));
-        if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_palette_image[i], NULL)) return 0;
+        if (!VKU_Alloc_Image_Object(s_image_mempool_texture, s_palette_image[i], NULL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) return 0;
 
         VkImageViewCreateInfo image_view_info = {
             VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
@@ -1784,61 +1784,92 @@ static int Render_To_Skybox_Image(void)
     };
     VKU_VR(vkCreateFramebuffer(s_gpu_device, &fb_info, NO_ALLOC_CALLBACK, &framebuffer));
 
-    VkImage linear_image;
-    VkImageCreateInfo image_info = {
-        VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, NULL, 0,
-        VK_IMAGE_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, { 1024, 1024, 1 }, 1, 6, VK_SAMPLE_COUNT_1_BIT,
-        VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_SAMPLED_BIT, VK_SHARING_MODE_EXCLUSIVE, 0,
-        NULL, VK_IMAGE_LAYOUT_UNDEFINED
-    };
-    VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &linear_image));
+	struct {
+		VkBuffer buffer;
+		VkDeviceMemory memory;
+	} staging_res;
 
-    VkMemoryRequirements mreq = { 0 };
-    vkGetImageMemoryRequirements(s_gpu_device, linear_image, &mreq);
+	VkBufferCreateInfo buffer_info = {
+		VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, NULL, 0,
+		1024 * 1024 * 4 * 6,
+		VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_SHARING_MODE_EXCLUSIVE, 0, NULL
+	};
+	VKU_VR(vkCreateBuffer(s_gpu_device, &buffer_info, NO_ALLOC_CALLBACK, &staging_res.buffer));
 
-    VkDeviceMemory linear_image_mem;
-    VkMemoryAllocateInfo alloc_info = {
-        VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq.size,
-        Get_Mem_Type_Index(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-    };
-    VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info, NO_ALLOC_CALLBACK, &linear_image_mem));
-    VKU_VR(vkBindImageMemory(s_gpu_device, linear_image, linear_image_mem, 0));
+	VkMemoryRequirements mreq_buffer = { 0 };
+	vkGetBufferMemoryRequirements(s_gpu_device, staging_res.buffer, &mreq_buffer);
 
-    VkImageView linear_image_view;
-    VkImageViewCreateInfo image_view_info = {
-        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
-        linear_image, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_FORMAT_R8G8B8A8_UNORM,
-        { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
-        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6 }
-    };
-    VKU_VR(vkCreateImageView(s_gpu_device, &image_view_info, NO_ALLOC_CALLBACK, &linear_image_view));
-
+	VkMemoryAllocateInfo alloc_info_buffer = {
+		VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq_buffer.size,
+		Get_Mem_Type_Index(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+	};
+	VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info_buffer, NO_ALLOC_CALLBACK, &staging_res.memory));
+	VKU_VR(vkBindBufferMemory(s_gpu_device, staging_res.buffer, staging_res.memory, 0));
 
     uint8_t *ptr;
-    VKU_VR(vkMapMemory(s_gpu_device, linear_image_mem, 0, VK_WHOLE_SIZE, 0, (void **)&ptr));
+    VKU_VR(vkMapMemory(s_gpu_device, staging_res.memory, 0, VK_WHOLE_SIZE, 0, (void **)&ptr));
 
     const char *name[6] = {
         "Data/Texture/Skybox_right1.png", "Data/Texture/Skybox_left2.png",
         "Data/Texture/Skybox_top3.png", "Data/Texture/Skybox_bottom4.png",
         "Data/Texture/Skybox_front5.png", "Data/Texture/Skybox_back6.png"
     };
-    for (int i = 0; i < 6; ++i) {
-        int w, h, comp;
-        stbi_uc *data = Load_Image(name[i], &w, &h, &comp, 4);
-        if (!data) LOG_AND_RETURN0();
 
-        VkImageSubresource sub = { VK_IMAGE_ASPECT_COLOR_BIT, 0, i };
-        VkSubresourceLayout layout;
-        vkGetImageSubresourceLayout(s_gpu_device, linear_image, &sub, &layout);
+	VkDeviceSize offset = 0;
+	VkBufferImageCopy buffer_copy_regions[6] = { 0 };
+	for (int i = 0; i < 6; ++i) {
+		int w, h, comp;
+		stbi_uc *data = Load_Image(name[i], &w, &h, &comp, 4);
+		if (!data) LOG_AND_RETURN0();
 
-        memcpy(ptr + layout.offset, data, w * h * comp);
-        stbi_image_free(data);
-    }
-    vkUnmapMemory(s_gpu_device, linear_image_mem);
+		size_t size = w * h * comp;
+		memcpy(ptr + offset, data, size);
 
+		buffer_copy_regions[i].bufferOffset = offset;
+		buffer_copy_regions[i].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		buffer_copy_regions[i].imageSubresource.baseArrayLayer = i;
+		buffer_copy_regions[i].imageSubresource.layerCount = 1;
+		buffer_copy_regions[i].imageExtent.width = w;
+		buffer_copy_regions[i].imageExtent.height = h;
+		buffer_copy_regions[i].imageExtent.depth = 1;
+
+		offset += size;
+		stbi_image_free(data);
+	}
+	vkUnmapMemory(s_gpu_device, staging_res.memory);
+
+	VkImage optimal_image;
+	VkImageCreateInfo image_info = {
+		VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, NULL, 0,
+		VK_IMAGE_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM,{ 1024, 1024, 1 }, 1, 6, VK_SAMPLE_COUNT_1_BIT,
+		VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_SHARING_MODE_EXCLUSIVE, 0,
+		NULL, VK_IMAGE_LAYOUT_UNDEFINED
+	};
+
+	VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &optimal_image));
+
+	VkMemoryRequirements mreq_image = { 0 };
+	vkGetImageMemoryRequirements(s_gpu_device, optimal_image, &mreq_image);
+
+	VkDeviceMemory optimal_image_mem;
+	VkMemoryAllocateInfo alloc_info_image = {
+		VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq_image.size,
+		Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+	};
+	VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info_image, NO_ALLOC_CALLBACK, &optimal_image_mem));
+	VKU_VR(vkBindImageMemory(s_gpu_device, optimal_image, optimal_image_mem, 0));
+
+	VkImageView optimal_image_view;
+	VkImageViewCreateInfo image_view_info = {
+		VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
+		optimal_image, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_FORMAT_R8G8B8A8_UNORM,
+		{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
+		{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6 }
+	};
+	VKU_VR(vkCreateImageView(s_gpu_device, &image_view_info, NO_ALLOC_CALLBACK, &optimal_image_view));
     Update_Common_Dset();
     VkDescriptorImageInfo image_sampler_attach = {
-        s_sampler, linear_image_view, VK_IMAGE_LAYOUT_GENERAL
+        s_sampler, optimal_image_view, VK_IMAGE_LAYOUT_GENERAL
     };
 
     VkWriteDescriptorSet update_sampler_font_image = {
@@ -1853,6 +1884,31 @@ static int Render_To_Skybox_Image(void)
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL, 0, NULL
     };
 
+	VkSubmitInfo submit_info;
+	submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	submit_info.pNext = NULL;
+	submit_info.waitSemaphoreCount = 0;
+	submit_info.pWaitSemaphores = NULL;
+	submit_info.pWaitDstStageMask = NULL;
+	submit_info.commandBufferCount = 1;
+	submit_info.pCommandBuffers = s_cmdbuf_display;
+	submit_info.signalSemaphoreCount = 0;
+	submit_info.pSignalSemaphores = NULL;
+
+	VKU_VR(vkBeginCommandBuffer(s_cmdbuf_display[0], &begin_info));
+	vkCmdCopyBufferToImage(s_cmdbuf_display[0], staging_res.buffer, optimal_image, VK_IMAGE_LAYOUT_GENERAL, 6, buffer_copy_regions);
+	VKU_VR(vkEndCommandBuffer(s_cmdbuf_display[0]));
+
+	if (vkQueueSubmit(s_gpu_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
+		LOG_AND_RETURN0();
+	}
+	if (vkQueueWaitIdle(s_gpu_queue) != VK_SUCCESS) {
+		LOG_AND_RETURN0();
+	}
+	
+	vkFreeMemory(s_gpu_device, staging_res.memory, NULL);
+	vkDestroyBuffer(s_gpu_device, staging_res.buffer, NULL);
+	
     VkImageSubresourceRange image_subresource_range;
     image_subresource_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_subresource_range.baseMipLevel = 0;
@@ -1869,7 +1925,7 @@ static int Render_To_Skybox_Image(void)
     linear_image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
     linear_image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     linear_image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    linear_image_memory_barrier.image = linear_image;
+    linear_image_memory_barrier.image = optimal_image;
     linear_image_memory_barrier.subresourceRange = image_subresource_range;
 
     VKU_VR(vkBeginCommandBuffer(s_cmdbuf_display[0], &begin_info));
@@ -1918,16 +1974,6 @@ static int Render_To_Skybox_Image(void)
     vkCmdEndRenderPass(s_cmdbuf_display[0]);
     VKU_VR(vkEndCommandBuffer(s_cmdbuf_display[0]));
 
-    VkSubmitInfo submit_info;
-    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submit_info.pNext = NULL;
-    submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
-    submit_info.commandBufferCount = 1;
-    submit_info.pCommandBuffers = s_cmdbuf_display;
-    submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
     if (vkQueueSubmit(s_gpu_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
         LOG_AND_RETURN0();
     }
@@ -1935,9 +1981,9 @@ static int Render_To_Skybox_Image(void)
         LOG_AND_RETURN0();
     }
 
-    VKU_DESTROY(vkDestroyImageView, linear_image_view);
-    VKU_DESTROY(vkDestroyImage, linear_image);
-    VKU_FREE_MEM(linear_image_mem);
+    VKU_DESTROY(vkDestroyImageView, optimal_image_view);
+    VKU_DESTROY(vkDestroyImage, optimal_image);
+    VKU_FREE_MEM(optimal_image_mem);
     for (int i = 0; i < 6; ++i) VKU_DESTROY(vkDestroyImageView, image_view[i]);
     VKU_DESTROY(vkDestroyFramebuffer, framebuffer);
 
@@ -1971,79 +2017,130 @@ static int Render_To_Palette_Images(void)
 
     VKU_VR(vkCreateFramebuffer(s_gpu_device, &fb_info, NO_ALLOC_CALLBACK, &framebuffer));
 
-    VkImage linear_image;
-    VkImageCreateInfo image_info = {
-        VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, NULL, 0,
-        VK_IMAGE_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM, { 256, 1, 1 }, 1, 6, VK_SAMPLE_COUNT_1_BIT,
-        VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_SAMPLED_BIT,
-        VK_SHARING_MODE_EXCLUSIVE, 0, NULL, VK_IMAGE_LAYOUT_UNDEFINED
-    };
-    VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &linear_image));
+	struct {
+		VkBuffer buffer;
+		VkDeviceMemory memory;
+	} staging_res;
 
-    VkMemoryRequirements mreq = { 0 };
-    vkGetImageMemoryRequirements(s_gpu_device, linear_image, &mreq);
+	VkBufferCreateInfo buffer_info = {
+		VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, NULL, 0,
+		256 * 4 * 6,
+		VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_SHARING_MODE_EXCLUSIVE, 0, NULL
+	};
+	VKU_VR(vkCreateBuffer(s_gpu_device, &buffer_info, NO_ALLOC_CALLBACK, &staging_res.buffer));
 
-    VkDeviceMemory linear_image_mem;
-    VkMemoryAllocateInfo alloc_info = {
-        VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq.size,
-        Get_Mem_Type_Index(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-    };
-    VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info, NO_ALLOC_CALLBACK, &linear_image_mem));
-    VKU_VR(vkBindImageMemory(s_gpu_device, linear_image, linear_image_mem, 0));
+	VkMemoryRequirements mreq_buffer = { 0 };
+	vkGetBufferMemoryRequirements(s_gpu_device, staging_res.buffer, &mreq_buffer);
 
+	VkMemoryAllocateInfo alloc_info_buffer = {
+		VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq_buffer.size,
+		Get_Mem_Type_Index(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+	};
+	VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info_buffer, NO_ALLOC_CALLBACK, &staging_res.memory));
+	VKU_VR(vkBindBufferMemory(s_gpu_device, staging_res.buffer, staging_res.memory, 0));
 
-    VkImageView linear_image_view;
-    VkImageViewCreateInfo image_view_info = {
-        VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
-        linear_image, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_FORMAT_R8G8B8A8_UNORM,
-        {
-            VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
-            VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A
-        },
-        { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6 }
-    };
-    VKU_VR(vkCreateImageView(s_gpu_device, &image_view_info, NO_ALLOC_CALLBACK, &linear_image_view));
+	uint8_t *ptr;
+	VKU_VR(vkMapMemory(s_gpu_device, staging_res.memory, 0, VK_WHOLE_SIZE, 0, (void **)&ptr));
 
-    uint8_t *ptr;
-    VKU_VR(vkMapMemory(s_gpu_device, linear_image_mem, 0, VK_WHOLE_SIZE, 0, (void **)&ptr));
+	const char *name[6] = {
+		"Data/Texture/Palette_Fire.png", "Data/Texture/Palette_Purple.png",
+		"Data/Texture/Palette_Muted.png", "Data/Texture/Palette_Rainbow.png",
+		"Data/Texture/Palette_Sky.png", "Data/Texture/Palette_Sky.png"
+	};
 
-    const char *name[] = {
-        "Data/Texture/Palette_Fire.png", "Data/Texture/Palette_Purple.png",
-        "Data/Texture/Palette_Muted.png", "Data/Texture/Palette_Rainbow.png",
-        "Data/Texture/Palette_Sky.png", "Data/Texture/Palette_Sky.png"
-    };
+	VkDeviceSize offset = 0;
+	VkBufferImageCopy buffer_copy_regions[6] = { 0 };
+	for (int i = 0; i < 6; ++i) {
+		int w, h, comp;
+		stbi_uc *data = Load_Image(name[i], &w, &h, &comp, 4);
+		if (!data) LOG_AND_RETURN0();
 
-    for (int i = 0; i < 6; ++i) {
-        int w, h, comp;
-        stbi_uc *data = Load_Image(name[i], &w, &h, &comp, 4);
-        if (!data) LOG_AND_RETURN0();
+		size_t size = w * h * comp;
+		memcpy(ptr + offset, data, size);
 
-        VkImageSubresource sub = { VK_IMAGE_ASPECT_COLOR_BIT, 0, i };
-        VkSubresourceLayout layout;
-        vkGetImageSubresourceLayout(s_gpu_device, linear_image, &sub, &layout);
+		buffer_copy_regions[i].bufferOffset = offset;
+		buffer_copy_regions[i].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		buffer_copy_regions[i].imageSubresource.baseArrayLayer = i;
+		buffer_copy_regions[i].imageSubresource.layerCount = 1;
+		buffer_copy_regions[i].imageExtent.width = w;
+		buffer_copy_regions[i].imageExtent.height = h;
+		buffer_copy_regions[i].imageExtent.depth = 1;
 
-        memcpy(ptr + layout.offset, data, w * h * comp);
+		offset += size;
+		stbi_image_free(data);
+	}
+	vkUnmapMemory(s_gpu_device, staging_res.memory);
 
-        stbi_image_free(data);
-    }
-    vkUnmapMemory(s_gpu_device, linear_image_mem);
+	VkImage optimal_image;
+	VkImageCreateInfo image_info = {
+		VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, NULL, 0,
+		VK_IMAGE_TYPE_2D, VK_FORMAT_R8G8B8A8_UNORM,{ 256, 1, 1 }, 1, 6, VK_SAMPLE_COUNT_1_BIT,
+		VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_SHARING_MODE_EXCLUSIVE, 0,
+		NULL, VK_IMAGE_LAYOUT_UNDEFINED
+	};
 
-    Update_Common_Dset();
-    VkDescriptorImageInfo image_sampler_attach = {
-        s_sampler, linear_image_view, VK_IMAGE_LAYOUT_GENERAL
-    };
+	VKU_VR(vkCreateImage(s_gpu_device, &image_info, NO_ALLOC_CALLBACK, &optimal_image));
 
-    VkWriteDescriptorSet update_sampler_font_image = {
-        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, s_common_dset[s_res_idx],
-        1, 0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &image_sampler_attach,
-        VK_NULL_HANDLE, VK_NULL_HANDLE
-    };
+	VkMemoryRequirements mreq_image = { 0 };
+	vkGetImageMemoryRequirements(s_gpu_device, optimal_image, &mreq_image);
 
-    vkUpdateDescriptorSets(s_gpu_device, 1, &update_sampler_font_image, 0, NULL);
+	VkDeviceMemory optimal_image_mem;
+	VkMemoryAllocateInfo alloc_info_image = {
+		VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, NULL, mreq_image.size,
+		Get_Mem_Type_Index(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+	};
+	VKU_VR(vkAllocateMemory(s_gpu_device, &alloc_info_image, NO_ALLOC_CALLBACK, &optimal_image_mem));
+	VKU_VR(vkBindImageMemory(s_gpu_device, optimal_image, optimal_image_mem, 0));
 
-    VkCommandBufferBeginInfo begin_info = {
-        VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL, 0, NULL
-    };
+	VkImageView optimal_image_view;
+	VkImageViewCreateInfo image_view_info = {
+		VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, NULL, 0,
+		optimal_image, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_FORMAT_R8G8B8A8_UNORM,
+		{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
+		{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6 }
+	};
+	VKU_VR(vkCreateImageView(s_gpu_device, &image_view_info, NO_ALLOC_CALLBACK, &optimal_image_view));
+	Update_Common_Dset();
+	VkDescriptorImageInfo image_sampler_attach = {
+		s_sampler, optimal_image_view, VK_IMAGE_LAYOUT_GENERAL
+	};
+
+	VkWriteDescriptorSet update_sampler_font_image = {
+		VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, NULL, s_common_dset[s_res_idx],
+		1, 0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, &image_sampler_attach,
+		VK_NULL_HANDLE, VK_NULL_HANDLE
+	};
+
+	vkUpdateDescriptorSets(s_gpu_device, 1, &update_sampler_font_image, 0, NULL);
+
+	VkCommandBufferBeginInfo begin_info = {
+		VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL, 0, NULL
+	};
+
+	VkSubmitInfo submit_info;
+	submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	submit_info.pNext = NULL;
+	submit_info.waitSemaphoreCount = 0;
+	submit_info.pWaitSemaphores = NULL;
+	submit_info.pWaitDstStageMask = NULL;
+	submit_info.commandBufferCount = 1;
+	submit_info.pCommandBuffers = s_cmdbuf_display;
+	submit_info.signalSemaphoreCount = 0;
+	submit_info.pSignalSemaphores = NULL;
+
+	VKU_VR(vkBeginCommandBuffer(s_cmdbuf_display[0], &begin_info));
+	vkCmdCopyBufferToImage(s_cmdbuf_display[0], staging_res.buffer, optimal_image, VK_IMAGE_LAYOUT_GENERAL, 6, buffer_copy_regions);
+	VKU_VR(vkEndCommandBuffer(s_cmdbuf_display[0]));
+
+	if (vkQueueSubmit(s_gpu_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
+		LOG_AND_RETURN0();
+	}
+	if (vkQueueWaitIdle(s_gpu_queue) != VK_SUCCESS) {
+		LOG_AND_RETURN0();
+	}
+
+	vkFreeMemory(s_gpu_device, staging_res.memory, NULL);
+	vkDestroyBuffer(s_gpu_device, staging_res.buffer, NULL);
 
     VkImageSubresourceRange image_subresource_range;
     image_subresource_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2061,7 +2158,7 @@ static int Render_To_Palette_Images(void)
     linear_image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
     linear_image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     linear_image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    linear_image_memory_barrier.image = linear_image;
+    linear_image_memory_barrier.image = optimal_image;
     linear_image_memory_barrier.subresourceRange = image_subresource_range;
 
     VkImageSubresourceRange palette_subresource_range[6];
@@ -2116,16 +2213,6 @@ static int Render_To_Palette_Images(void)
     vkCmdEndRenderPass(s_cmdbuf_display[0]);
     VKU_VR(vkEndCommandBuffer(s_cmdbuf_display[0]));
 
-    VkSubmitInfo submit_info;
-    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submit_info.pNext = NULL;
-    submit_info.waitSemaphoreCount = 0;
-    submit_info.pWaitSemaphores = NULL;
-    submit_info.pWaitDstStageMask = NULL;
-    submit_info.commandBufferCount = 1;
-    submit_info.pCommandBuffers = s_cmdbuf_display;
-    submit_info.signalSemaphoreCount = 0;
-    submit_info.pSignalSemaphores = NULL;
     if (vkQueueSubmit(s_gpu_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
         LOG_AND_RETURN0();
     }
@@ -2133,9 +2220,9 @@ static int Render_To_Palette_Images(void)
         LOG_AND_RETURN0();
     }
 
-    VKU_DESTROY(vkDestroyImageView, linear_image_view);
-    VKU_DESTROY(vkDestroyImage, linear_image);
-    VKU_FREE_MEM(linear_image_mem);
+    VKU_DESTROY(vkDestroyImageView, optimal_image_view);
+    VKU_DESTROY(vkDestroyImage, optimal_image);
+    VKU_FREE_MEM(optimal_image_mem);
     for (int i = 0; i < 6; ++i) VKU_DESTROY(vkDestroyImageView, image_view[i]);
     VKU_DESTROY(vkDestroyFramebuffer, framebuffer);
 
@@ -2910,7 +2997,7 @@ static uint32_t Get_Mem_Type_Index(VkMemoryPropertyFlagBits bit)
     vkGetPhysicalDeviceMemoryProperties(s_gpu, &physMemProperties);
 
     for (uint32_t i = 0; i < physMemProperties.memoryTypeCount; ++i) {
-        if (physMemProperties.memoryTypes[i].propertyFlags & bit || bit == VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+        if ((physMemProperties.memoryTypes[i].propertyFlags & bit) == bit) {
             return  i;
         }
     }

--- a/Src/Stardust_VK.c
+++ b/Src/Stardust_VK.c
@@ -161,6 +161,7 @@ static int                              s_win_idx;
 static VkDevice                         s_gpu_device;
 static VkQueue                          s_gpu_queue;
 static VkPhysicalDevice                 s_gpu;
+static VkPhysicalDeviceProperties       s_gpu_properties;
 static VkImage                          s_win_images[k_Window_Buffering];
 static VkImageView                      s_win_image_view[k_Window_Buffering];
 static VkFramebuffer                    s_win_framebuffer[k_Window_Buffering];
@@ -2869,6 +2870,7 @@ static int Generate_Text(void)
  
     s_font_letter_count += Add_Text(&ptr, str, 10, s_glob_state->height - 90);
     s_font_letter_count += Add_Text(&ptr, "Stardust 1.1", 10, s_glob_state->height - 60);
+    s_font_letter_count += Add_Text(&ptr, s_gpu_properties.deviceName, 10, s_glob_state->height - 30);
 
     vkUnmapMemory(s_gpu_device, s_font_buffer_mem[s_res_idx]);
 
@@ -2926,6 +2928,8 @@ int VK_Init(struct glob_state_t* state)
         return STARDUST_NOT_SUPPORTED;
     }
     Log("VK Device initialized\n");
+
+	vkGetPhysicalDeviceProperties(s_gpu, &s_gpu_properties);
 
     if (!Demo_Init()) {
         Log("Demo_Init failed\n");

--- a/Src/Stardust_VK.c
+++ b/Src/Stardust_VK.c
@@ -3094,8 +3094,11 @@ int VK_Run(struct glob_state_t *state)
         VKU_DESTROY(vkDestroySemaphore, s_swap_chain_image_ready_semaphore);
     }
 
-    uint32_t swap_image_index = 0xffffffff;
-    VKU_Present(&swap_image_index);
+	if (s_exit_code != STARDUST_EXIT)
+	{
+		uint32_t swap_image_index = 0xffffffff;
+		VKU_Present(&swap_image_index);
+	}
 
     s_res_idx = 0;
     s_win_idx = 0;


### PR DESCRIPTION
This is the major PR containing everything necessary to have the demo run on hardware from different vendors. I have successfully tested this with NVIDIA and AMD on recent Vulkan drivers.

**Note that I don't have a windows setup with an Intel GPU to test this on (my ultrabook with Haswell only runs Ubuntu), so you may want to test and make sure that it still works on Intel with these changes.** From the experience with my samples (that also run on Intel under Linux) these changes should not break anything, but better check before a merge :wink: 

The major changes to get this working :
**Use staging**
Most GPUs have very limited support for linear tiled images. So this example uses optimal tiled images and copies the image data over from a buffer. This should work on all vendors.

**Lookup memory type indices**
Not all vendors offer a device local memory type at index 0, so the memory type index will be passed to all VKU_Alloc_Image_Object calls to make sure the right memory type index for the given memory property bits is selected.

Note that I haven't updated the .exe, I'll leave that up to you if everything looks okay from your side :+1: 
